### PR TITLE
added ability to specify athena ctas options

### DIFF
--- a/dbt/include/athena/macros/adapters.sql
+++ b/dbt/include/athena/macros/adapters.sql
@@ -61,12 +61,17 @@
 {% endmacro %}
 
 
-{% macro athena__format_ctas_options(_format, _compression, _partitioned_by, _bucketed_by, _bucket_count, _external_location) %}
-  {%- set opts = '' %}
-  {%- if _format -%}
-    {%- set opts = " format='" + _format + "'" -%}
-  {% endif %}
-
+{% macro athena__format_ctas_options() %}
+  {%- set _fmt = config.get('format') -%}
+  {%- set _compression = config.get('compression') -%}
+  {%- set _partitioned_by = config.get('partitioned_by') -%}
+  {%- set _bucketed_by = config.get('bucketed_by') -%}
+  {%- set _bucket_count = config.get('bucket_count') -%}
+  {%- set _external_location = config.get('external_location') -%}
+  {%- set opts = '' -%}
+  {%- if _fmt -%}
+    {%- set opts = " format='" + _fmt + "'" -%}
+  {%- endif -%}
   {%- if _compression -%}
     {%- if _format == 'orc'-%}
       {%- set opts = opts + ", orc_compression='" + _compression + "'" -%}
@@ -74,43 +79,30 @@
       {%- set opts = opts + ", parquet_compression='" + _compression + "'" -%}
     {%- endif -%}
   {%- endif -%}
-
   {%- if _partitioned_by -%}
-    {%- if opts != '' -%}{%- set opts = opts + ',' -%}{% endif %}
+    {%- if opts != '' -%}{%- set opts = opts + ',' -%}{%- endif -%}
     {% set cols = '' %}
     {%- set opts = opts + " partitioned_by=ARRAY" + _partitioned_by | tojson | replace('"', "'") -%}
   {%- endif -%}
-
   {%- if _bucketed_by -%}
-    {%- if opts != '' -%}{%- set opts = opts + ',' -%}{% endif %}
-    {% set cols = '' %}
+    {%- if opts != '' -%}{%- set opts = opts + ',' -%}{%- endif -%}
+    {%- set cols = '' -%}
     {%- set opts = opts + " bucketed_by=ARRAY" + _bucketed_by | tojson | replace('"', "'") -%}
   {%- endif -%}
-
-  {%if _bucket_count %}
-    {% if opts != ''%}{% set opts = opts + ',' %}{% endif %}
-    {% set opts = opts + " bucket_count=" + _bucket_count %}
-  {% endif %}
-
-  {%if _external_location%}
-    {% if opts != ''%}{% set opts = opts + ',' %}{% endif %}
-    {% set opts = opts + " external_location='" + _external_location + "'"%}
-  {% endif %}
-
-  {{ return(opts)}} 
-{% endmacro%}
+  {%- if _bucket_count -%}
+    {%- if opts != ''%}{% set opts = opts + ',' -%}{%- endif -%}
+    {%- set opts = opts + " bucket_count=" + _bucket_count -%}
+  {%- endif -%}
+  {%- if _external_location -%}
+    {%- if opts != ''%}{% set opts = opts + ',' -%}{%- endif -%}
+    {%- set opts = opts + " external_location='" + _external_location + "'" -%}
+  {%- endif -%}
+  {%- if opts -%}WITH ({{ opts }}){%- endif -%} 
+{% endmacro %}
 
 {% macro athena__create_table_as(temporary, relation, sql) -%}
-  {%- set _fmt = config.get('format') -%}
-  {%- set _comp= config.get('compression') -%}
-  {%- set _part= config.get('partitioned_by') -%}
-  {%- set _buck= config.get('bucketed_by') -%}
-  {%- set _num_buck = config.get('bucket_count') -%}
-  {%- set _loc = config.get('external_location') -%}
-  {%- set opts = athena__format_ctas_options(_fmt, _comp, _part, _buck, _num_buck, _loc) -%}
   create table
-    {{ relation }}
-    {% if opts %} WITH ({{ opts }}){% endif %}
+    {{ relation }} {{ athena__format_ctas_options() }}
   as (
     -- wrapping to select allows to use "with" statements inside "create table"
     select * from (

--- a/test/unit/macros/test_materializations.py
+++ b/test/unit/macros/test_materializations.py
@@ -1,0 +1,30 @@
+from jinja2 import Environment, FileSystemLoader
+
+config_test_ctas_options = {
+    'format': 'parquet',
+    'compression': 'snappy',
+    'partitioned_by': ['col1', 'col2'],
+    'bucketed_by': ['col3'],
+    'external_location': 's3://a/b/c/'
+}
+
+path = 'dbt/include/athena/macros'
+fname = 'adapters.sql'
+
+def test_athena__format_ctas_options():
+
+    env = Environment(loader=FileSystemLoader(path))
+    env.globals = env.make_globals(d={'config': config_test_ctas_options})
+    module = env.get_template(fname).module
+    expected = ("WITH ( format='parquet', partitioned_by=ARRAY['col1', 'col2'], "
+                "bucketed_by=ARRAY['col3'], external_location='s3://a/b/c/')")
+    actual = module.athena__format_ctas_options()
+    assert expected == actual
+
+def test_athena__format_ctas_options_blank():
+    env = Environment(loader=FileSystemLoader(path))
+    env.globals = env.make_globals(d={'config': {}})
+    module = env.get_template(fname).module
+    expected = ''
+    actual = module.athena__format_ctas_options()
+    assert expected == actual


### PR DESCRIPTION
adds the ability to specify properties to CTAS queries in athena, as documented here: https://docs.aws.amazon.com/athena/latest/ug/create-table-as.html

the following properties will be parsed:

* format
* partitioned_by
* bucketed_by
* compression -- both orc & parquet compression are specified via this property.
* external_location

The following properties are not supported because text format output is less of a priority for me.
* field_delimiter

Example of using a CTAS query

```
{{ config(materialized='table',
          format='parquet',
          compression='snappy',
          partitioned_by=['id','email'])

}}
with source_data as (
    select 'hal' name, 1 as id, 'hal@hal.hal' as email
    union all select 'hal', 1, 'hal@hal.hal'
    union all select 'hal', 1, 'hal@hal.hal'
    union all select 'hal', 1, 'hal@hal.hal'
    union all select 'hal', 1, 'hal@hal.hal'
    union all select 'hal', 1, 'hal@hal.hal'
    union all select 'hal', 1, 'hal@hal.hal'
    union all select 'hal', 1, 'hal@hal.hal'
)
select * from source_data
```

This generates the following sql when run on athena:

```
create table
    testdb.my_first_dbt_model
     WITH ( format='parquet', parquet_compression='snappy', partitioned_by=ARRAY['id', 'email'])
  as (
    -- wrapping to select allows to use "with" statements inside "create table"
    select * from (
with source_data as (
    select 'hal' name, 1 as id, 'hal@hal.hal' as email
    union all select 'hal', 1, 'hal@hal.hal'
    union all select 'hal', 1, 'hal@hal.hal'
    union all select 'hal', 1, 'hal@hal.hal'
    union all select 'hal', 1, 'hal@hal.hal'
    union all select 'hal', 1, 'hal@hal.hal'
    union all select 'hal', 1, 'hal@hal.hal'
    union all select 'hal', 1, 'hal@hal.hal'
)
select * from source_data
```
Limitations:

You can't partition / bucket by a column if its name requires quoting, and it is not yet possible to provide columns that are quoted. The reason is that I cheated in rendering the `ARRAY['col1', 'col2']` bits. The current implementation uses the jinja filter pipeline `| tojson | replace('"', "'")`, which is only able to handle the case with one set of double-quotes.

For instance

`partitioned_by=['"id"','"email"']` would yield a mangled query, however

`partitioned_by=['id','email']` would work fine, yielding the query above.
