### PR TITLE
update setup.py dbt-core version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
             "include/athena/macros/*/*.sql",
         ]
     },
-    install_requires=["dbt-core=={}".format(package_version), "PyAthena"],
+    install_requires=["dbt-core>={}".format(package_version), "PyAthena"],
 )


### PR DESCRIPTION
the install is now permitted to proceed with any dbt-core version at or above 0.16.1